### PR TITLE
PR for fixing scrapper with UI changes + corner cases bug

### DIFF
--- a/snow-request.js
+++ b/snow-request.js
@@ -219,10 +219,9 @@ var SnowRequest = function() {
       var issued = TimeUtil.fixIssueDateFormat($($('.location-issued__no-wrap')[5]).text() + $($('.location-issued__no-wrap')[6]).text());
 
       forecastOptObj.issuedDate = issued;
-      let lastUpdateDate = $($('.location-issued__no-wrap')[6]).text() 
       let firstTime = $($('.forecast-table-time__period')[0]).text();
       forecastOptObj.startDay = $($('.forecast-table-days__name')[0]).text();
-      forecastOptObj.lastUpdateDate = lastUpdateDate;
+      forecastOptObj.lastUpdateDate = $($('.location-issued__no-wrap')[6]).text();
       //if the first column starts from 'night', first column would not display day.
       if(firstTime === 'night'){
         forecastOptObj.startDay = TimeUtil.getPrevDay(forecastOptObj.startDay);

--- a/snow-request.js
+++ b/snow-request.js
@@ -67,7 +67,7 @@ var SnowRequest = function() {
   */
   function pBuildForecast($, forecastOpt, cb) {
     //Get various forecast information containers
-    var firstTime = $($('table tr.lar.hea2 td span.tiny.en')[0]).text();
+    var firstTime = $($('.forecast-table-time__period')[0]).text();
     var snowForecast = $('span.snow');
     var rainForecast = $('span.rain');
     var freezingLevel = $('span.heightfl');
@@ -96,7 +96,7 @@ var SnowRequest = function() {
     //Loop over forecasts, get relevant information for each and push to temp array
     for(var i = 0; i < MAX_CELLS; i++){
       var cellObj = {
-        date: TimeUtil.getDay(forecastOpt.issuedDate, forecastOpt.startDay, TimeUtil.getTimeOffset(firstTime), i),
+        date: TimeUtil.getDay(forecastOpt.lastUpdateDate, forecastOpt.startDay, TimeUtil.getTimeOffset(firstTime), i),
         time: TimeUtil.getTime(TimeUtil.getTimeOffset(firstTime), forecastOpt.startDay, i), //issued[1] is startDay
         summary: $(summary[i]).text(),
         wind: parseInt($(winds[i]).text(), 10),
@@ -217,8 +217,17 @@ var SnowRequest = function() {
       forecastOptObj.isMetric = $('.deg-c input').attr('checked') === 'checked';
       //Extrapolate time-relevant information needed to build forecast, and build object.
       var issued = TimeUtil.fixIssueDateFormat($($('.location-issued__no-wrap')[5]).text() + $($('.location-issued__no-wrap')[6]).text());
+
       forecastOptObj.issuedDate = issued;
-      forecastOptObj.startDay = $($('table tr.day-names td')[0]).text();
+      let lastUpdateDate = $($('.location-issued__no-wrap')[6]).text() 
+      let firstTime = $($('.forecast-table-time__period')[0]).text();
+      forecastOptObj.startDay = $($('.forecast-table-days__name')[0]).text();
+      forecastOptObj.lastUpdateDate = lastUpdateDate;
+      //if the first column starts from 'night', first column would not display day.
+      if(firstTime === 'night'){
+        forecastOptObj.startDay = TimeUtil.getPrevDay(forecastOptObj.startDay);
+      }
+
       var match = issued.match(/^\d+/);
       var time = [];
       var timeIndex = issued.indexOf(match[0]) + match[0].length;

--- a/time-util.js
+++ b/time-util.js
@@ -65,16 +65,17 @@ TimeUtil = {
     * PUBLIC
     * Helper method that uses the Moment API to get the day of
     * the current forecast cell.
-    * issuedDate: The date when the forecast was issued.
+    * lastUpdateDate: The date when the forecast was last updated. Ex. '28 Dec 2019'
     * startDay: The first day in the snow forecast.
     * startTime: The first time in the snow forecast.
     * index: Current index, ranges from 0 to MAX_INDEX_CNT(17).
     *
     * returns: day: string object e.g. 8th Sep 2015
     */
-    getDay: function(issuedDate, startDay, startTime, index){
+    getDay: function(lastUpdateDate, startDay, startTime, index){
       var offset = Math.floor((startTime + index)/this.times.length);
-      return moment().add(offset, 'days').format("Do MMM YY");
+      let issueDateObj = moment(lastUpdateDate, "DD-MMM-YYYY");
+      return issueDateObj.add(offset, 'days').format("Do MMM YY");
     },
 
     /*
@@ -115,7 +116,23 @@ TimeUtil = {
 
       return tmpDate[0] + tmpDate[1].trim() + ' ' + tmpDate[2] + ' ' + tmpDate[3].trim() +
         ' ' + tmpDate[4];
+    },
+    
+    /*
+    * PUBLIC
+    * Helper function to get the previous day of the week given a day
+    * input would always be complete word since it would have enough space to display it in the second column.
+    * This function does not support abbreviation input
+    * 
+    * startDay: the day when the first column starts on, ex. 'Monday'
+    * 
+    * returns: a string ie: 'Sunday'
+    */
+    getPrevDay: function(startDay){
+      index = this.days.indexOf(startDay);
+      return index === 0? this.days[6] : this.days[index-1];
     }
+
 };
 
 module.exports = TimeUtil;


### PR DESCRIPTION
Hi there, here are a couple bugs with the new snow-forecast.com UI changes that I found out and fixed, if I can get a code review to get these fixed would be greatly appreciated. Let me know if you have any questions.

The unit test that fails look unrelated to my changes. Also just a small suggestion, maybe just have one parseRequest in each `describe`  and store the result instead of calling a request in every `it` statement ? This way it can make the unit test a lot faster.

## Bug #1 Incorrect ‘startDay’ due to class name change. 
ex. startDay is day of week, 'Monday' , 'Tuesday'
- Updated new class name 

## Bug #2  Incorrect  ‘startTime’ due to class name change.   
ex. AM | PM | night
- Updated new class name 

## Bug #3 (**See screenshot**) 
If the first column startTime starts from ‘night’, The first column no longer display which day is it in a week, which will cause the problem when we fetch the first day inside the row, we fetch the second day instead. 
Ex. When it starts from Friday Night, the first day we scrape would be ’Saturday’, since Friday doesn’t show anymore, it only show the expand arrow.  (Fixed)
<img width="728" alt="Screen Shot 2019-12-28 at 1 38 31 AM" src="https://user-images.githubusercontent.com/58281533/71551392-3d19eb80-299b-11ea-88b9-2da15e2fa852.png">

- Solution:
If statement to check it `startTime == night`, 
If it is use a `getPrevDay()` helper function to get the correct day.

## Bug#4 : 
 The package is using a logic to add current date plus days calculated based on index to get the date of a column.  Something like   ```moment().add(offset, ’days’)``` in  **TimeUtil.getDay()**

(Date would be wrong in the following scenario):
if the current time has passed 12am, but snow-forecast hasn’t update to the next day, the first day will still have two column PM/ night on Dec 27th , However, the scrapped data would start from Dec 28 for the first column since it has passed 12 AM.

-Solution: 
Use the `lastUpdateDate` to construct the moment object instead of current time. So we can get the correct date in this corner case.

## Tests Performed:
- npm link the local copy of node_module to try scrape data from snow-forecast 
- data matches result on snow-forecast.com.
- tested corner case when startTime  is night
- tested corner case when current time passed 12am but snow-forecast still show the previous day.