### PR TITLE
change fetch method of isMetric and issuedDate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 index.js
 /lib
 .idea/
-.yarn.lock
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snow-forecast-sfr",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "An NPM module that scrapes snow-forecast for the relevant resort and returns its information.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/SnowRequest.ts
+++ b/src/SnowRequest.ts
@@ -187,10 +187,10 @@ const SnowRequest = function (): ISnowRequest {
         }
 
         // Find out if response is in metric or not.
-        const isMetric = $('.deg-c input').attr('checked') === 'checked';
+        const isMetric = $('.units-metric#body').length === 1;
         // Extrapolate time-relevant information needed to build forecast, and build object.
         const issuedDate = TimeUtil.fixIssueDateFormat(
-          $($('.location-issued__no-wrap')[5]).text() + $($('.location-issued__no-wrap')[6]).text(),
+          $($('.location-issued__no-wrap')[2]).text() + $($('.location-issued__no-wrap')[3]).text(),
         );
 
         const firstTime = $($('.forecast-table-time__period')[0]).text();


### PR DESCRIPTION
The element of choosing Metric or Imperial and the location of the issued date has been changed. This pull request fixed the issue caused by snow-forecast.com page structure update.

Also bumped up the version to 2.0.2.
